### PR TITLE
cmake: improve install prefix handling and clarity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,10 @@ cmake_minimum_required (VERSION 3.23.1)
 project(openmoonray)
 
 list(APPEND CMAKE_MESSAGE_CONTEXT ${PROJECT_NAME})
-if(NOT DEFINED CMAKE_INSTALL_PREFIX OR ${CMAKE_INSTALL_PREFIX} STREQUAL "/usr/local")
-    set(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR}/release)
+# Set default install prefix to local release directory if not explicitly provided
+# or if default system path (/usr/local) is being used.
+if(NOT DEFINED CMAKE_INSTALL_PREFIX OR CMAKE_INSTALL_PREFIX STREQUAL "/usr/local")
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_SOURCE_DIR}/release")
 endif()
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/cmake)
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/rats/cmake)

--- a/docs/build-troubleshooting.md
+++ b/docs/build-troubleshooting.md
@@ -1,0 +1,18 @@
+# Build Troubleshooting
+
+## Common Errors
+
+### Missing submodules
+Fix:
+git submodule update --init --recursive
+
+### Missing dependencies
+Install:
+- libtbb-dev
+- libjsoncpp-dev
+- libopenexr-dev
+
+### TBB not found (modern systems)
+Use:
+-DCMAKE_PREFIX_PATH=/usr/lib/x86_64-linux-gnu/cmake
+


### PR DESCRIPTION
## Summary
Minor improvement to install prefix handling in root CMake configuration.

## Changes
- Replaced CMAKE_SOURCE_DIR with CMAKE_CURRENT_SOURCE_DIR for correctness
- Added explanatory comment to clarify default install behavior

## Motivation
Improves correctness of path handling and makes intent clearer for maintainers.

## Testing
- Build configured successfully using CMake
- No functional changes to build output observed