### PR TITLE
Align macOS Python runtime paths for Houdini 22

### DIFF
--- a/scripts/macOS/setupHoudini.sh
+++ b/scripts/macOS/setupHoudini.sh
@@ -1,6 +1,6 @@
 omr_install_dir=/Applications/MoonRay/installs/openmoonray
 
-# save/restore PYTHONPATH, since Houdini seems to reject python3.9
+# save/restore PYTHONPATH, since Houdini supplies its own Python runtime
 OLDPP=${PYTHONPATH}
 source ${omr_install_dir}/scripts/setup.sh
 export PYTHONPATH=${OLDPP}

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -25,8 +25,9 @@ echo "Setting up release in ${omr_root}"
 # NB required for Arras to function (it needs to find execComp)
 export PATH=${omr_root}/bin:${PATH}
 
-# need python modules for the USD interface and for the RATS tests
-export PYTHONPATH=${install_root}/lib/python:/usr/local/lib/python:${install_root}/lib64/python3.9/site-packages/:${PYTHONPATH}
+# Need Python modules for the USD interface and the RATS tests.  The macOS
+# Houdini build installs its bindings for Python 3.13.
+export PYTHONPATH=${omr_root}/python/lib/python3.13:${install_root}/lib/python3.13/site-packages:${install_root}/lib/python:${install_root}/lib64/python3.9/site-packages:/usr/local/lib/python:${PYTHONPATH}
 
 
 # tell moonray where to find dsos


### PR DESCRIPTION
<!-- template v2 -->
## Compatibility:
build

## Issues/Tickets:
OpenMoonRay/openmoonray#276

## Release notes comment:
Updated the MoonRay environment setup for Houdini 22’s Python 3.13 runtime.

## Comments for the reviewer:
The setup environment now includes the Python 3.13 locations used by the Houdini 22 macOS build:

- `${omr_root}/python/lib/python3.13`
- `${install_root}/lib/python3.13/site-packages`

The existing `lib64/python3.9/site-packages` path is retained for compatibility with current non-macOS installations. This is a small refinement over the umbrella implementation, which replaced that path entirely.

The macOS Houdini setup continues to preserve Houdini’s own `PYTHONPATH` after loading the general MoonRay environment.

Both modified shell scripts pass syntax validation.

## Look or scene setup change:
No expected look changes.

## Special notes for production:

## Attention/Reviewers:

## AI Assisted Development:
Assisted-by: OpenAI Codex / GPT-5.6

## Checklist:
- [ ] Documentation has been updated.
- [ ] Includes new unit tests.
- [ ] Includes new RATS tests.